### PR TITLE
Update tinygo version in CI to (0.31.1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install TinyGo
       uses: ./.github/actions/install-tinygo
       with:
-        tinygo-version: '0.29.0'
+        tinygo-version: '0.31.1'
     - name: Setup Fastly CLI
       uses: fastly/compute-actions/setup@v5
     - name: Build and test


### PR DESCRIPTION
This PR updates the version of TinyGo used by CI to 0.31.
This version adds Go 1.22 support, which would now be installed by default by the `actions/setup-go@v4` with `version: 'stable'`.
